### PR TITLE
Allow build pipeline to write

### DIFF
--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -5,7 +5,8 @@ on:
     - main
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -5,12 +5,14 @@ on:
     - main
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Add back write permissions to pipeline. Otherwise it won't be able to actually deploy GH pages.